### PR TITLE
Update OWNERS and OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - release-managers
+  - sig-release-leads
+  - release-engineering-approvers
+reviewers:
+  - release-engineering-approvers
+  - release-engineering-reviewers
+labels:
+  - sig/release
+  - area/release-eng

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,25 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+aliases:
+  sig-release-leads:
+    - cpanato # SIG Technical Lead
+    - jeremyrickard # SIG Chair
+    - justaugustus # SIG Chair
+    - puerco # SIG Technical Lead
+    - saschagrunert # SIG Chair
+    - Verolop # SIG Technical Lead
+  release-engineering-approvers:
+    - cpanato # subproject owner / Release Manager
+    - jeremyrickard # subproject owner / Release Manager
+    - justaugustus # subproject owner / Release Manager
+    - palnabarun # Release Manager
+    - puerco # subproject owner / Release Manager
+    - saschagrunert # subproject owner / Release Manager
+    - xmudrii # Release Manager
+    - Verolop # subproject owner / Release Manager
+  release-engineering-reviewers:
+    - ameukam # Release Manager Associate
+    - cici37 # Release Manager Associate
+    - jimangel # Release Manager Associate
+    - jrsapi # Release Manager Associate
+    - salaxander # Release Manager Associate


### PR DESCRIPTION
This PR updates `OWNERS` and `OWNERS_ALIASES` to match our other repositories.

Note: we might want to add @nitishfy as an reviewer/approver at some point in the future

/assign @puerco @jeremyrickard 
cc @kubernetes-sigs/release-engineering 