### PR TITLE
[WIP] feat: add  `reconcile` command for obs cli

### DIFF
--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+	path "sigs.k8s.io/obscli/path"
+	"sigs.k8s.io/obscli/types"
+	"sigs.k8s.io/release-sdk/obs"
+	"sigs.k8s.io/yaml"
+)
+
+type Options struct {
+	ManifestPath string
+	OBSClient    *obs.OBS
+}
+
+type Info struct {
+	Username string
+	Password string
+	APIURL   string
+}
+
+func Reconcile() *cobra.Command {
+	ctx := context.Background()
+	opts := &Options{}
+	info := &Info{
+		Username: "Nitish",
+		Password: "",
+		APIURL:   "https://api.opensuse.org/",
+	}
+	o := obs.New((*obs.Options)(info))
+
+	cmd := &cobra.Command{
+		Use:   "reconcile",
+		Short: "reconcile command for Paketo",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			manifestPath, _ := cmd.Flags().GetString("manifest")
+			opts.ManifestPath = manifestPath
+
+			err := GetManifestPath(opts)
+			if err != nil {
+				fmt.Printf("%v", err)
+				return
+			}
+
+			prjs, err := LoadManifest(manifestPath)
+			if err != nil {
+				fmt.Errorf("unable to load the manifest file: %v", err)
+				return
+			}
+
+			for _, prj := range prjs.Projects {
+				remotePrj, err := o.GetProjectMetaFile(ctx, prj.Project.Name)
+				if err != nil {
+					fmt.Printf("%v", err)
+					return
+				}
+				if remotePrj == nil || remotePrj.Name != prj.Name {
+					fmt.Printf("Project %s doesn't exit!", prj.Name)
+					return
+				}
+			}
+
+			fmt.Println("Project exists!")
+		},
+	}
+	cmd.Flags().StringP("manifest", "m", "", "path to read manifest")
+	return cmd
+}
+
+func LoadManifest(filepath string) (*types.Projects, error) {
+	content, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read the file content: %v", err)
+	}
+
+	var prjs types.Projects
+	err = yaml.Unmarshal(content, &prjs)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling yaml: %v", err)
+	}
+
+	return &prjs, nil
+}
+
+func GetManifestPath(opts *Options) error {
+	if opts.ManifestPath != "" {
+		// if path is absolute, it is transformed from root path to a rel path
+		initialCWD, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get the current working directory: %w", err)
+		}
+
+		manifestPathFlag, err := path.GetRelativePathFromCWD(initialCWD, opts.ManifestPath)
+		if err != nil {
+			return err
+		}
+		opts.ManifestPath = manifestPathFlag
+
+		// when the manifest path is set by the cmd flag, we are moving cwd so the cmd is executed from that dir
+		uptManifestPath, err := path.UpdateCWDtoManifestPath(opts.ManifestPath)
+		if err != nil {
+			return err
+		}
+		opts.ManifestPath = uptManifestPath
+
+		if _, err := os.Stat(opts.ManifestPath); errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%s file doesn't exist", opts.ManifestPath)
+		}
+	}
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "paketo",
+	Short: "Paketo: facilitates interaction with the OpenBuildServices platform to manage Kubernetes packages for new releases",
+	Long:  "Paketo: facilitates interaction with the OpenBuildServices platform to manage Kubernetes packages for new releases",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Kubernetes OBS ClI Tool")
+	},
+}
+
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(Reconcile())
+}

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,13 @@ module sigs.k8s.io/obscli
 
 go 1.21.4
 
-require sigs.k8s.io/release-sdk v0.10.4
+require (
+	github.com/spf13/cobra v1.8.0
+	sigs.k8s.io/release-sdk v0.10.4
+	sigs.k8s.io/yaml v1.4.0
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,9 @@ module sigs.k8s.io/obscli
 go 1.21.4
 
 require sigs.k8s.io/release-sdk v0.10.4
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.8.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -10,3 +11,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 sigs.k8s.io/release-sdk v0.10.4 h1:Ji75SfmHXTaZUUKteCUWEIHKJkOk8H0uxTuRdEnbBQU=
 sigs.k8s.io/release-sdk v0.10.4/go.mod h1:H9TsZQFDpdAmViPe69C4OkP8vlOPZ0YUmf1dqUNiqZ4=
+sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
+sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 sigs.k8s.io/release-sdk v0.10.4 h1:Ji75SfmHXTaZUUKteCUWEIHKJkOk8H0uxTuRdEnbBQU=
 sigs.k8s.io/release-sdk v0.10.4/go.mod h1:H9TsZQFDpdAmViPe69C4OkP8vlOPZ0YUmf1dqUNiqZ4=

--- a/main.go
+++ b/main.go
@@ -14,19 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package types
+package main
 
-import (
-	"sigs.k8s.io/release-sdk/obs"
-)
+import "sigs.k8s.io/obscli/cmd"
 
-type Projects struct {
-	Projects []Project `json:"projects"`
-}
-
-type Project struct {
-	obs.Project
-	RootProject string        `json:"rootProject,omitempty"`
-	Packages    []obs.Package `json:"packages,omitempty"`
-	Subprojects []Project     `json:"subprojects,omitempty"`
+func main() {
+	cmd.Execute()
 }

--- a/path/path.go
+++ b/path/path.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package path
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// GetWorkdirFromManifestPath sets the path
+func GetWorkdirFromManifestPath(manifestPath string) string {
+	dir := filepath.Dir(manifestPath)
+	if filepath.Base(dir) == ".okteto" {
+		dir = filepath.Dir(dir)
+	}
+	return dir
+}
+
+func GetRelativePathFromCWD(cwd, path string) (string, error) {
+	if path == "" || !filepath.IsAbs(path) {
+		return path, nil
+	}
+
+	relativePath, err := filepath.Rel(cwd, path)
+	if err != nil {
+		return "", err
+	}
+	return relativePath, nil
+}
+
+// GetManifestPathFromWorkdir returns the path from a workdir
+func GetManifestPathFromWorkdir(manifestPath, workdir string) string {
+	mPath, err := filepath.Rel(workdir, manifestPath)
+	if err != nil {
+		return ""
+	}
+	return mPath
+}
+
+func UpdateCWDtoManifestPath(manifestPath string) (string, error) {
+	workdir := GetWorkdirFromManifestPath(manifestPath)
+	if err := os.Chdir(workdir); err != nil {
+		return "", err
+	}
+	updatedManifestPath := GetManifestPathFromWorkdir(manifestPath, workdir)
+	return updatedManifestPath, nil
+}


### PR DESCRIPTION
- add `reconcile` command for the obs-cli tool
- For a basic use, it's just checking the project name locally and remotely for now. The main functionality can be added once we're done with initial set of review.

